### PR TITLE
Expose the KO-locus DB args to the CLI and reduce iterative DB parsing

### DIFF
--- a/kleborate/modules/klebsiella_pneumo_complex__kaptive/klebsiella_pneumo_complex__kaptive.py
+++ b/kleborate/modules/klebsiella_pneumo_complex__kaptive/klebsiella_pneumo_complex__kaptive.py
@@ -16,17 +16,11 @@ If not, see <https://www.gnu.org/licenses/>.
 """
 
 import os
-import pathlib
 from pathlib import Path
 import shutil
 import sys
-import dna_features_viewer
-from dna_features_viewer import GraphicFeature, GraphicRecord
 
-# Add the kaptive path
-# sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../kaptive')))
-
-from kaptive.database import Database, get_database, load_database
+from kaptive.database import load_database
 from kaptive.misc import check_python_version, check_programs, get_logo, check_cpus, check_file
 from kaptive.assembly import typing_pipeline
 
@@ -41,9 +35,9 @@ def prerequisite_modules():
 
 def get_headers():
     full_headers = [
-        'K_locus', 'K_type', 'K_locus_confidence', 'K_locus_problems', 'K_locus_identity', 
-        'K_Missing_expected_genes', 
-        'O_locus', 'O_type', 'O_locus_confidence', 'O_locus_problems', 'O_locus_identity', 
+        'K_locus', 'K_type', 'K_locus_confidence', 'K_locus_problems', 'K_locus_identity',
+        'K_Missing_expected_genes',
+        'O_locus', 'O_type', 'O_locus_confidence', 'O_locus_problems', 'O_locus_identity',
         'O_Missing_expected_genes'
     ]
     stdout_headers = []
@@ -54,15 +48,18 @@ def add_cli_options(parser):
     module_name = os.path.basename(__file__)[:-3]
     group = parser.add_argument_group(f'{module_name} module')
     group.add_argument('-t', '--threads', type=check_cpus, default=8, metavar='',
-                      help="Kaptive number of threads for alignment (default: %(default)s)")
-
+                       help="Kaptive number of threads for alignment (default: %(default)s)")
+    group.add_argument('--k-db', type=load_database, default=load_database('kpsc_k'), metavar='',
+                       help="Kaptive database for K-locus typing (default: kpsc_k)")
+    group.add_argument('--o-db', type=load_database, default=load_database('kpsc_k'), metavar='',
+                       help="Kaptive database for O-locus typing (default: kpsc_o)")
     return group
 
 
 def check_cli_options(args):
     if args.threads < 1:
         raise ValueError("The number of threads must be at least 1.")
-    
+
 
 def check_external_programs():
     if not shutil.which('minimap2'):
@@ -73,28 +70,26 @@ def check_external_programs():
 # define all headers
 
 all_headers = [
-        'Assembly', 'locus', 'type', 'locus confidence',
-        'locus problems', 'locus identity', 'Coverage', 'Length discrepancy', 
-        'Expected genes in locus', 'Expected genes in locus, details', 
-        'Missing expected genes', 'Other genes in locus', 
-        'Other genes in locus, details', 'Expected genes outside locus', 
-        'Expected genes outside locus, details', 'Other genes outside locus', 
-        'Other genes outside locus, details', 'Truncated genes, details'
-    ]
+    'Assembly', 'locus', 'type', 'locus confidence',
+    'locus problems', 'locus identity', 'Coverage', 'Length discrepancy',
+    'Expected genes in locus', 'Expected genes in locus, details',
+    'Missing expected genes', 'Other genes in locus',
+    'Other genes in locus, details', 'Expected genes outside locus',
+    'Expected genes outside locus, details', 'Other genes outside locus',
+    'Other genes outside locus, details', 'Truncated genes, details'
+]
+
 
 def get_results(assembly, minimap2_index, args, previous_results):
     full_headers, _ = get_headers()
-
-    k_db = load_database('kpsc_k')
-    o_db = load_database('kpsc_o')
 
     assembly_path = Path(assembly)
 
     results_dict = {}
 
-    k_results = typing_pipeline(assembly_path, k_db, threads=args.threads)
+    k_results = typing_pipeline(assembly_path, args.k_db, threads=args.threads)
     if k_results is not None:
-        k_result_table = k_results.format('tsv') 
+        k_result_table = k_results.format('tsv')
         for line in k_result_table.split('\n'):
             if line:
                 parts = line.split('\t')
@@ -105,9 +100,9 @@ def get_results(assembly, minimap2_index, args, previous_results):
     else:
         print("Warning: No gene alignments sufficient for typing. Skipping k_results processing.")
 
-    o_results = typing_pipeline(assembly_path, o_db, threads=args.threads)
+    o_results = typing_pipeline(assembly_path, args.o_db, threads=args.threads)
     if o_results is not None:
-        o_result_table = o_results.format('tsv') 
+        o_result_table = o_results.format('tsv')
         for line in o_result_table.split('\n'):
             if line:
                 parts = line.split('\t')
@@ -125,5 +120,3 @@ def get_results(assembly, minimap2_index, args, previous_results):
     results_dict = {k: (v if v else '-') for k, v in results_dict.items()}
 
     return results_dict
-    
-


### PR DESCRIPTION
This allows users to specify the databases, but also allows database parsing to occur during argument parsing so it is not happening for every assembly.